### PR TITLE
Filtering for scraped jobs SDE ONLY

### DIFF
--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -5,6 +5,7 @@ import { CreateJobDto } from './dto/create-job.dto';
 import { Job } from './entities/job.entity';
 import { InjectBrowser } from 'nest-puppeteer';
 import { Page, Browser } from 'puppeteer';
+import { softwareDeveloper } from './searchTerms';
 
 @Injectable()
 export class JobsService {
@@ -22,9 +23,28 @@ export class JobsService {
     return url;
   }
 
+  private addAdditionalSearchterms(search: string, searchTerms: string[]) {
+    const completeSearchTerms: string[] = [];
+    if (search.toLowerCase() === 'software developer') {
+      completeSearchTerms.concat(softwareDeveloper);
+      return completeSearchTerms;
+    }
+  }
+
+  private filterForRelevantJobs(
+    createJobDtoArray: CreateJobDto[],
+    job: string,
+  ) {
+    let searchTermArray = job.split(' ');
+    searchTermArray = this.addAdditionalSearchterms(job, searchTermArray);
+
+    const search = new RegExp('remote', 'i');
+    const filtered: CreateJobDto[] = [];
+  }
+
   private addRemoteBoolean(createJobDtoArray: CreateJobDto[]) {
-    let remote = new RegExp('remote', 'i');
-    let remoteChecked: CreateJobDto[] = [];
+    const remote = new RegExp('remote', 'i');
+    const remoteChecked: CreateJobDto[] = [];
     for (let i = 0; i < createJobDtoArray.length; i++) {
       let createJobDto: CreateJobDto = createJobDtoArray[i];
       if (createJobDtoArray[i].location.search(remote) === -1) {

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -23,7 +23,7 @@ export class JobsService {
     return url;
   }
 
-  private addAdditionalSearchterms(search: string) {
+  private addAdditionalSearchTerms(search: string) {
     let completeSearchTerms: string[] = search.split(' ');
     if (search.includes('developer')) {
       completeSearchTerms = completeSearchTerms.concat(softwareDeveloper);
@@ -40,7 +40,7 @@ export class JobsService {
   ) {
     const removedJobs: CreateJobDto[] = [];
     const filteredJobs: CreateJobDto[] = [];
-    let searchTermArray = this.addAdditionalSearchterms(job);
+    let searchTermArray = this.addAdditionalSearchTerms(job);
     for (let i = 0; i < createJobDtoArray.length; i++) {
       let test = searchTermArray.some((term) => {
         return createJobDtoArray[i].title.toLowerCase().includes(term);
@@ -48,6 +48,11 @@ export class JobsService {
       if (test) filteredJobs.push(createJobDtoArray[i]);
       else removedJobs.push(createJobDtoArray[i]);
     }
+    // to verify results being filtered out
+    removedJobs.forEach((job) => {
+      console.log(job.title);
+    });
+    console.log(removedJobs.length);
     return filteredJobs;
   }
 

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -25,7 +25,7 @@ export class JobsService {
 
   private addAdditionalSearchterms(search: string, searchTerms: string[]) {
     const completeSearchTerms: string[] = [];
-    if (search.toLowerCase() === 'software developer') {
+    if (search.toLowerCase().includes('developer')) {
       completeSearchTerms.concat(softwareDeveloper);
       return completeSearchTerms;
     }

--- a/src/jobs/searchTerms.ts
+++ b/src/jobs/searchTerms.ts
@@ -1,0 +1,7 @@
+// search term: software developer
+const softwareDeveloper: string[] = ['engineer', 'engineering'];
+
+// search term: graphic designer
+const graphicDesiner: string[] = [''];
+
+export { softwareDeveloper, graphicDesiner };

--- a/src/jobs/searchTerms.ts
+++ b/src/jobs/searchTerms.ts
@@ -23,7 +23,7 @@ const softwareDeveloper: string[] = [
   'react',
   '.net',
   'java',
-  'c',
+  ' c ',
   'c#',
   'c++',
   'javascript',
@@ -39,6 +39,11 @@ const softwareDeveloper: string[] = [
   'rest',
   'api',
   'ionic',
+  'sql',
+  'development',
+  'node.js',
+  'js',
+  'wordpress',
 ];
 
 // search term: graphic designer
@@ -47,4 +52,4 @@ const graphicDesiner: string[] = [' '];
 // search term: graphic designer
 const uxui: string[] = ['ux/ui', 'user experience', 'user interface'];
 
-export { softwareDeveloper, graphicDesiner };
+export { softwareDeveloper, graphicDesiner, uxui };

--- a/src/jobs/searchTerms.ts
+++ b/src/jobs/searchTerms.ts
@@ -1,7 +1,50 @@
+const BasefieldSearches: string[] = [
+  'software developer',
+  'back end developer',
+  'front end devloper',
+  'graphic designer',
+  'ux ui',
+  'data analytics',
+];
+
+const locationSearches: string[] = [
+  'washington',
+  'seattle',
+  'bellevue',
+  'california',
+  'san francisco',
+  'la',
+];
+
 // search term: software developer
-const softwareDeveloper: string[] = ['engineer', 'engineering'];
+const softwareDeveloper: string[] = [
+  'engineer',
+  'engineering',
+  'react',
+  '.net',
+  'java',
+  'c',
+  'c#',
+  'c++',
+  'javascript',
+  'typescript',
+  'go',
+  'golang',
+  'angular',
+  'python',
+  'apache',
+  'ruby',
+  'core',
+  'mvc',
+  'rest',
+  'api',
+  'ionic',
+];
 
 // search term: graphic designer
-const graphicDesiner: string[] = [''];
+const graphicDesiner: string[] = [' '];
+
+// search term: graphic designer
+const uxui: string[] = ['ux/ui', 'user experience', 'user interface'];
 
 export { softwareDeveloper, graphicDesiner };


### PR DESCRIPTION
## Description:
Indeed often includes ads or irrelevant results to a given query. The goal was to some implement a level of filtering to maintain relevancy of scraped jobs. 


`searchTerms.ts` - contains arrays for base searches and keywords to be used when filtering results from the base searches

`addAdditionalSearchTerms` - takes base the search and splits it, then concatenates additional keywords from `searchTerms.ts` returning the array completeSearchTerms.

`filterForRelevantJobs` - filters scraped jobs using the searchTermArray provided by `addAdditionalSearchTerms`. Each job title is checked against the searchTermArray and added to filteredJobs after the first match. If no matches are found the job will be added to removedJobs. filteredJobs is then returned and removedJobs is logged to verify accuracy.

## Issues:
Currently, this functionality only works for the software developer search. Although, a skeleton functionality is laid out for other searches. Additionally, the keywords in the `searchTerms.ts` are hand written just based of what I could think of off the top of my head, and some top keywords for sde job postings. Therefore, at this time is not a comprehensive approach and could possibly remove relevant jobs or allow irrelevant ones. For this reason I have left the console log of removedJobs. The thought being that later in development I can persist these and check them for relevancy and add additional keywords based on jobs that were incorrectly filtered.  
